### PR TITLE
change regex to end on Ctrl-Z (i.e. \x1A), exclude from param matching group

### DIFF
--- a/lib/eiscp/iscp_message.rb
+++ b/lib/eiscp/iscp_message.rb
@@ -17,7 +17,7 @@ class EISCP
 
 
   # REGEX
-  REGEX = /(?<start>!)?(?<unit_type>\d)?(?<command>[A-Z]{3})\s?(?<parameter>\S+)/
+  REGEX = /(?<start>!)?(?<unit_type>\d)?(?<command>[A-Z]{3})\s?(?<parameter>.*)\cZ/
 
   def initialize(command, parameter, unit_type = "1", start = "!")
     if unit_type == nil


### PR DESCRIPTION
As far as I can tell, the "parameter" portion of a message can validly include spaces (e.g. a "NAT", "QSTN" should return the currently playing artist from USB/NET, which can include spaces, e.g. "ISCP!1NATPink Floyd"). The old regex would return only "Pink" as the parameter returned from the Onkyo device. 

And obviously, [Pink](http://en.wikipedia.org/wiki/Pink_%28singer%29) and [Pink Floyd](http://en.wikipedia.org/wiki/Pink_Floyd) are quite different. :)

As far as I can tell, messages actually end in \x1A. This change terminates the parameter group when it encounters that character. 

Great stuff, by the way, Mike! I appreciate your effort in building this. I'm building a higher level library (e.g. stuff like `instance.stop`; `instance.station = "93.9"`) using this library. If you're amenable, I may send you more pull requests as I work on it.
